### PR TITLE
前端数据-考表

### DIFF
--- a/CQUark/.idea/gradle.xml
+++ b/CQUark/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/CQUark/app/build.gradle
+++ b/CQUark/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'org.cqumsc.cquark'
-    compileSdk 32
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "org.cqumsc.cquark"
         minSdk 23
-        targetSdk 32
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
 
@@ -34,7 +34,8 @@ android {
         viewBinding true
     }
 }
-
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.7.0'
@@ -45,7 +46,15 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.1'
     implementation 'androidx.navigation:navigation-ui-ktx:2.4.1'
+
+    implementation 'com.squareup.moshi:moshi-kotlin:1.9.3'
+    implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+    // Room dependency
+    implementation 'androidx.room:room-runtime:2.4.2'
+    kapt 'androidx.room:room-compiler:2.4.2'
 }

--- a/CQUark/app/src/main/AndroidManifest.xml
+++ b/CQUark/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -11,6 +13,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.CQUark"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/CQUark/app/src/main/java/org/cqumsc/cquark/database/DataBaseEntities.kt
+++ b/CQUark/app/src/main/java/org/cqumsc/cquark/database/DataBaseEntities.kt
@@ -1,0 +1,11 @@
+package org.cqumsc.cquark.database
+
+import com.squareup.moshi.Json
+
+//和后端对接需修改！！
+data class ExamInfo(
+    val id: String,
+    @Json(name = "img_src") val imgSrcUrl: String,
+    val type: String,
+    val price: Double
+)

--- a/CQUark/app/src/main/java/org/cqumsc/cquark/front_net/ExamApiService.kt
+++ b/CQUark/app/src/main/java/org/cqumsc/cquark/front_net/ExamApiService.kt
@@ -1,0 +1,32 @@
+package org.cqumsc.cquark.front_net
+
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.cqumsc.cquark.database.ExamInfo
+import retrofit2.converter.moshi.MoshiConverterFactory
+//BASE_URL待修改
+private const val BASE_URL = "http://192.168.10.45:5000"
+
+private val moshi = Moshi.Builder()
+    .add(KotlinJsonAdapterFactory())
+    .build()
+
+private val retrofit = Retrofit.Builder()
+    .addConverterFactory(MoshiConverterFactory.create(moshi))
+    .baseUrl(BASE_URL)
+    .build()
+
+interface ExamApiService {
+    @GET("realestate") //如果需要指定路径或端点
+    suspend fun getInfo():
+            List<ExamInfo>
+}
+
+//初始化Retrofit
+object ExamApi {
+    val retrofitService : ExamApiService by lazy {
+        retrofit.create(ExamApiService::class.java) }
+}
+

--- a/CQUark/app/src/main/java/org/cqumsc/cquark/ui/slideshow/SlideshowFragment.kt
+++ b/CQUark/app/src/main/java/org/cqumsc/cquark/ui/slideshow/SlideshowFragment.kt
@@ -29,7 +29,7 @@ class SlideshowFragment : Fragment() {
         val root: View = binding.root
 
         val textView: TextView = binding.textSlideshow
-        slideshowViewModel.text.observe(viewLifecycleOwner) {
+        slideshowViewModel.response.observe(viewLifecycleOwner) {
             textView.text = it
         }
         return root

--- a/CQUark/app/src/main/java/org/cqumsc/cquark/ui/slideshow/SlideshowViewModel.kt
+++ b/CQUark/app/src/main/java/org/cqumsc/cquark/ui/slideshow/SlideshowViewModel.kt
@@ -3,11 +3,30 @@ package org.cqumsc.cquark.ui.slideshow
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import org.cqumsc.cquark.front_net.ExamApi
 
 class SlideshowViewModel : ViewModel() {
 
-    private val _text = MutableLiveData<String>().apply {
-        value = "This is slideshow Fragment"
+    private val _response = MutableLiveData<String>()
+    val response: LiveData<String>
+        get() = _response
+
+    init {
+        getExamInfo()
     }
-    val text: LiveData<String> = _text
+
+    //需要改动
+    private fun getExamInfo() {
+        viewModelScope.launch {
+            try {
+                val listResult = ExamApi.retrofitService.getInfo()
+                val separator = "-"
+                _response.value = listResult.joinToString()
+            } catch (e: Exception) {
+                _response.value = "Failure: ${e.message}"
+            }
+        }
+    }
 }

--- a/CQUark/app/src/main/res/xml/network_security_config.xml
+++ b/CQUark/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>


### PR DESCRIPTION
可以实现从后端获得并解析json,数据目前直接呈现在Slideshow中.

与后端对接时.至少需要修改ExamApiService中的BASE_URL和DataBaseEntities中的ExamInfo 与前端对接时.至少需要修改SlideshowViewModel中的getExamInfo

!!!未实现将json缓存或保存至本地